### PR TITLE
Customize URI scheme

### DIFF
--- a/bitcoiner.gemspec
+++ b/bitcoiner.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'typhoeus', '~> 1.3.0'
+  spec.add_dependency 'addressable'
 
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'minitest', '~> 5.0'

--- a/lib/bitcoiner.rb
+++ b/lib/bitcoiner.rb
@@ -3,6 +3,7 @@
 require 'bitcoiner/version'
 require 'typhoeus'
 require 'json'
+require "addressable"
 
 %w[client account account_hash transaction].each do |f|
   require File.join(File.dirname(__FILE__), 'bitcoiner', f)

--- a/lib/bitcoiner/client.rb
+++ b/lib/bitcoiner/client.rb
@@ -7,8 +7,8 @@ module Bitcoiner
 
     def initialize(user, pass, host)
       uri = Addressable::URI.heuristic_parse(host)
-      uri.user = user
-      uri.password = pass
+      uri.user ||= user
+      uri.password ||= pass
       self.endpoint = uri.to_s
     end
 

--- a/lib/bitcoiner/client.rb
+++ b/lib/bitcoiner/client.rb
@@ -5,8 +5,11 @@ module Bitcoiner
 
     attr_accessor :endpoint
 
-    def initialize(user, pass, host = '127.0.0.1:8332')
-      self.endpoint = "http://#{user}:#{pass}@#{host}"
+    def initialize(user, pass, host)
+      uri = Addressable::URI.heuristic_parse(host)
+      uri.user = user
+      uri.password = pass
+      self.endpoint = uri.to_s
     end
 
     def balance

--- a/lib/bitcoiner/client.rb
+++ b/lib/bitcoiner/client.rb
@@ -2,8 +2,11 @@
 
 module Bitcoiner
   class Client
+
+    attr_accessor :endpoint
+
     def initialize(user, pass, host = '127.0.0.1:8332')
-      @endpoint = "http://#{user}:#{pass}@#{host}"
+      self.endpoint = "http://#{user}:#{pass}@#{host}"
     end
 
     def balance
@@ -17,14 +20,14 @@ module Bitcoiner
 
     def request(method, *args)
       post_body = { 'method' => method, 'params' => args, 'id' => 'jsonrpc' }.to_json
-      response = Typhoeus.post(@endpoint, body: post_body)
+      response = Typhoeus.post(endpoint, body: post_body)
       response_hash = JSON.parse response.body
       raise JSONRPCError, response_hash['error'] if response_hash['error']
       response_hash['result']
     end
 
     def inspect
-      "#<Bitcoiner::Client #{@endpoint.inspect} >"
+      "#<Bitcoiner::Client #{endpoint.inspect} >"
     end
 
     class JSONRPCError < RuntimeError; end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -60,4 +60,9 @@ class ClientTest < Minitest::Test
     client = Bitcoiner::Client.new("username", "password", "https://host.com")
     assert_equal 'https://username:password@host.com', client.endpoint
   end
+
+  should "prioritize the credentials in the host" do
+    client = Bitcoiner::Client.new("username", "password", "https://abc:123@host.com")
+    assert_equal 'https://abc:123@host.com', client.endpoint
+  end
 end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -55,4 +55,9 @@ class ClientTest < Minitest::Test
     client = Bitcoiner::Client.new("username", "password", "host.com")
     assert_equal 'http://username:password@host.com', client.endpoint
   end
+
+  should "allow setting of uri scheme" do
+    client = Bitcoiner::Client.new("username", "password", "https://host.com")
+    assert_equal 'https://username:password@host.com', client.endpoint
+  end
 end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -50,4 +50,9 @@ class ClientTest < Minitest::Test
       end
     end
   end
+
+  should "allow setting of host" do
+    client = Bitcoiner::Client.new("username", "password", "host.com")
+    assert_equal 'http://username:password@host.com', client.endpoint
+  end
 end


### PR DESCRIPTION
Allow setting of URI scheme:

```ruby
Bitcoiner::Client.new("user", "pass", "https://hostname")
```

The reason I need this I use a testnet that is hosted elsewhere for integration tests.