### PR TITLE
Include response's error message when JSONRPCError

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.4.2
+  - 2.6.0
 before_install: gem install bundler -v 1.16.1

--- a/lib/bitcoiner/client.rb
+++ b/lib/bitcoiner/client.rb
@@ -71,10 +71,11 @@ module Bitcoiner
       if response.success?
         JSON.parse(response.body)
       else
-        error_message = %i[code return_code].map do |attr|
-          "#{attr}: `#{response.send(attr)}`"
-        end.join(', ')
-        raise JSONRPCError, "unsuccessful response; #{error_message}"
+        error_messages = %i[code return_code].each_with_object({}) do |attr, hash|
+          hash[attr] = response.send(attr)
+        end
+        error_messages[:body] = response.body
+        raise JSONRPCError, error_messages.map {|k, v| "#{k}: `#{v}`"}.join("; ")
       end
     end
   end


### PR DESCRIPTION
Sometimes bitcoind returns 500 and I do not know why. To help debug, this should also print the response's body as bitcoind's response supposedly includes it:

https://github.com/bitcoin/bitcoin/issues/12673#issuecomment-372334718